### PR TITLE
Better handling of manifest changes after download

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ hand or generate it using some other method.
                // The language for this artifact. (optional)
                "language": "en",
                // The apk checksums are returned from apksigner. (optional)
-               // The format is: signingVersion:algorithm:base64encodedValue
+               // The format is: signingVersion:algorithm:base64UrlEncodedValue
                // Currently v2:sha256 & v2:sha512 are supported.
                // While this argument is optional it is highly recommend you provide it.
                "checksums": [

--- a/self-update-core/src/main/kotlin/me/tatarka/android/selfupdate/ArtifactState.kt
+++ b/self-update-core/src/main/kotlin/me/tatarka/android/selfupdate/ArtifactState.kt
@@ -1,0 +1,103 @@
+package me.tatarka.android.selfupdate
+
+import me.tatarka.android.selfupdate.manifest.Manifest
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+internal class ArtifactState(
+    val url: HttpUrl,
+    val bytesWritten: BytesWritten = BytesWritten.Zero,
+    val size: Long = 0L,
+)
+
+internal fun artifactStates(
+    manifestUrl: HttpUrl,
+    artifacts: List<Manifest.Artifact>,
+    metadata: Map<String, ArtifactMetadata> = emptyMap(),
+): Map<String, ArtifactState> {
+    return artifacts.associate { artifact ->
+        val name = nameArtifact(artifact)
+        val path = artifact.path
+        val url = manifestUrl.relativePath(path)
+        val artifactMetadata = metadata[name]
+        name to ArtifactState(
+            url = url,
+            bytesWritten = artifactMetadata?.bytesWritten ?: BytesWritten.Zero,
+            size = artifactMetadata?.size ?: -1L
+        )
+    }
+}
+
+internal fun canReuseSession(
+    versionCode: Long,
+    newArtifactNames: Set<String>,
+    metadata: ReleaseMetadata,
+): Boolean {
+    // A different version can never be reused
+    if (versionCode != metadata.versionCode) return false
+    // artifacts can't be deleted from a session so it can't be reused if artifacts have been
+    // removed or changed
+    if (newArtifactNames.size < metadata.artifacts.size) return false
+    val currentNames = metadata.artifacts.keys
+    if (currentNames.any { name -> name !in newArtifactNames }) return false
+    return true
+}
+
+
+private fun nameArtifact(artifact: Manifest.Artifact): String {
+    val checksum = checksum(artifact)
+    // name should be unique and stable
+    return buildString {
+        val baseName = artifact.path.removeSuffix("/")
+            .substringAfterLast('/')
+        append(baseName)
+        if (checksum != null) {
+            append('-')
+            append(checksum)
+        } else {
+            if (artifact.abi != null) {
+                append('-')
+                append(artifact.abi)
+            }
+            if (artifact.density != null) {
+                append('-')
+                append(artifact.density)
+            }
+            if (artifact.language != null) {
+                append('-')
+                append(artifact.language)
+            }
+        }
+    }
+}
+
+private fun checksum(artifact: Manifest.Artifact): String? {
+    val checksums = artifact.checksums
+    if (checksums.isNullOrEmpty()) return null
+    // sort to ensure consist ordering
+    return checksums.min().substringAfterLast(":")
+}
+
+private fun HttpUrl.relativePath(path: String): HttpUrl {
+    return path.toHttpUrlOrNull() ?: run {
+        if (path.startsWith("/")) {
+            HttpUrl.Builder()
+                .scheme(scheme)
+                .port(port)
+                .host(host)
+                .addPathSegments(path.removePrefix("/"))
+                .build()
+        } else {
+            newBuilder()
+                .apply {
+                    if (pathSize > 0) {
+                        removePathSegment(pathSize - 1)
+                    }
+                }
+                .addPathSegments(path)
+                .build()
+        }
+    }
+}
+
+

--- a/self-update-core/src/main/kotlin/me/tatarka/android/selfupdate/ReleaseMetadata.kt
+++ b/self-update-core/src/main/kotlin/me/tatarka/android/selfupdate/ReleaseMetadata.kt
@@ -5,41 +5,65 @@ import kotlin.math.absoluteValue
 
 internal class ReleaseMetadata(val versionCode: Long) {
     val artifacts = mutableMapOf<String, ArtifactMetadata>()
+}
 
-    internal class ArtifactMetadata {
-        var size: Long = 0
-        var bytesWritten: Long = 0
-        var checksum: String? = null
+internal class ArtifactMetadata {
+    var size: Long = 0
+    var bytesWritten: BytesWritten = BytesWritten.Zero
+}
 
-        fun isDownloadComplete(): Boolean {
-            return bytesWritten < 0
-        }
-
-        fun markDownloadComplete(sizeBytes: Long) {
-            bytesWritten = -sizeBytes.absoluteValue
+internal fun ReleaseMetadata.update(response: DownloadResponse) {
+    for (artifactResponse in response.artifactResponses) {
+        artifacts.getOrPut(artifactResponse.name) {
+            ArtifactMetadata()
+        }.apply {
+            bytesWritten = artifactResponse.bytesWritten
+            size = artifactResponse.size
         }
     }
 }
 
-private const val VersionCode = "v"
-private const val Artifacts = "a"
-private const val Size = "s"
-private const val BytesWritten = "b"
-private const val Checksum = "c"
+@JvmInline
+internal value class BytesWritten(val rawValue: Long) : Comparable<Long> {
+    val bytes: Long get() = rawValue.absoluteValue
+    val complete: Boolean get() = rawValue < 0
+
+    companion object {
+        val Zero = BytesWritten(0)
+        fun complete(bytes: Long): BytesWritten = BytesWritten(-bytes.absoluteValue)
+    }
+
+    operator fun plus(bytes: Long): BytesWritten {
+        require(!complete) { "cannot add bytes to completed" }
+        return BytesWritten(rawValue + bytes)
+    }
+
+    override fun compareTo(other: Long): Int {
+        return bytes.compareTo(other)
+    }
+
+    override fun toString(): String {
+        return bytes.toString()
+    }
+}
+
+private const val KeyVersionCode = "v"
+private const val KeyArtifacts = "a"
+private const val KeySize = "s"
+private const val KeyBytesWritten = "b"
 
 internal fun PersistableBundle.toReleaseMetadata(): ReleaseMetadata? {
-    val versionCode = getLong(VersionCode, -1)
+    val versionCode = getLong(KeyVersionCode, -1)
     if (versionCode == -1L) return null
     val result = ReleaseMetadata(versionCode)
-    val artifacts = getPersistableBundle(Artifacts)
+    val artifacts = getPersistableBundle(KeyArtifacts)
     if (artifacts != null) {
         for (name in artifacts.keySet().orEmpty()) {
             val artifact = artifacts.getPersistableBundle(name)
             if (artifact != null) {
-                result.artifacts[name] = ReleaseMetadata.ArtifactMetadata().apply {
-                    size = artifact.getLong(Size)
-                    bytesWritten = artifact.getLong(BytesWritten)
-                    checksum = artifact.getString(Checksum)
+                result.artifacts[name] = ArtifactMetadata().apply {
+                    size = artifact.getLong(KeySize)
+                    bytesWritten = BytesWritten(artifact.getLong(KeyBytesWritten))
                 }
             }
         }
@@ -50,14 +74,13 @@ internal fun PersistableBundle.toReleaseMetadata(): ReleaseMetadata? {
 
 internal fun ReleaseMetadata.toPersistableBundle(): PersistableBundle {
     return PersistableBundle().apply {
-        putLong(VersionCode, versionCode)
+        putLong(KeyVersionCode, versionCode)
         if (artifacts.isNotEmpty()) {
-            putPersistableBundle(Artifacts, PersistableBundle().apply {
+            putPersistableBundle(KeyArtifacts, PersistableBundle().apply {
                 for ((name, artifact) in artifacts) {
                     putPersistableBundle(name, PersistableBundle().apply {
-                        putLong(Size, artifact.size)
-                        putLong(BytesWritten, artifact.bytesWritten)
-                        putString(Checksum, artifact.checksum)
+                        putLong(KeySize, artifact.size)
+                        putLong(KeyBytesWritten, artifact.bytesWritten.rawValue)
                     })
                 }
             })

--- a/self-update-core/src/main/kotlin/me/tatarka/android/selfupdate/compat/PersistableBundleCompat.kt
+++ b/self-update-core/src/main/kotlin/me/tatarka/android/selfupdate/compat/PersistableBundleCompat.kt
@@ -1,9 +1,10 @@
-package me.tatarka.android.selfupdate
+package me.tatarka.android.selfupdate.compat
 
 import android.os.Build
 import android.os.PersistableBundle
 import android.util.Xml
 import androidx.annotation.RequiresApi
+import me.tatarka.android.selfupdate.XmlUtils
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
 import org.xmlpull.v1.XmlSerializer

--- a/self-update-core/src/test/java/me/tatarka/android/selfupdate/ArtifactStateTest.kt
+++ b/self-update-core/src/test/java/me/tatarka/android/selfupdate/ArtifactStateTest.kt
@@ -1,0 +1,79 @@
+package me.tatarka.android.selfupdate
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class ArtifactStateTest {
+    @Test
+    fun canReuseSession_returns_true_if_no_artifacts_have_been_downloaded() {
+        val versionCode = 1L
+        val artifactNames = setOf("base")
+        val metadata = ReleaseMetadata(versionCode = 1L)
+
+        assertThat(canReuseSession(versionCode, artifactNames, metadata)).isTrue()
+    }
+
+    @Test
+    fun canReuseSession_returns_true_if_some_artifacts_have_been_downloaded() {
+        val versionCode = 1L
+        val artifactNames = setOf("base", "split")
+        val metadata = ReleaseMetadata(versionCode = 1L)
+        metadata.artifacts["base"] = ArtifactMetadata().apply {
+            bytesWritten = BytesWritten.complete(1)
+        }
+
+        assertThat(canReuseSession(versionCode, artifactNames, metadata)).isTrue()
+    }
+
+    @Test
+    fun canReuseSession_returns_true_if_all_artifacts_have_been_downloaded() {
+        val versionCode = 1L
+        val artifactNames = setOf("base", "split")
+        val metadata = ReleaseMetadata(versionCode = 1L)
+        metadata.artifacts["base"] = ArtifactMetadata().apply {
+            bytesWritten = BytesWritten.complete(1)
+        }
+        metadata.artifacts["split"] = ArtifactMetadata().apply {
+            bytesWritten = BytesWritten.complete(1)
+        }
+
+        assertThat(canReuseSession(versionCode, artifactNames, metadata)).isTrue()
+    }
+
+    @Test
+    fun canReuseSession_returns_false_if_version_changed() {
+        val versionCode = 1L
+        val artifactNames = setOf("base")
+        val metadata = ReleaseMetadata(versionCode = 2L)
+
+        assertThat(canReuseSession(versionCode, artifactNames, metadata)).isFalse()
+    }
+
+    @Test
+    fun canReuseSession_returns_false_if_artifacts_are_removed() {
+        val versionCode = 1L
+        val artifactNames = setOf("base")
+        val metadata = ReleaseMetadata(versionCode = 1L)
+        metadata.artifacts["base"] = ArtifactMetadata().apply {
+            bytesWritten = BytesWritten.complete(1)
+        }
+        metadata.artifacts["split"] = ArtifactMetadata()
+
+        assertThat(canReuseSession(versionCode, artifactNames, metadata)).isFalse()
+    }
+
+    @Test
+    fun canReuseSession_returns_false_if_artifacts_change() {
+        val versionCode = 1L
+        val artifactNames = setOf("base", "split2")
+        val metadata = ReleaseMetadata(versionCode = 1L)
+        metadata.artifacts["base"] = ArtifactMetadata().apply {
+            bytesWritten = BytesWritten.complete(1)
+        }
+        metadata.artifacts["split1"] = ArtifactMetadata()
+
+        assertThat(canReuseSession(versionCode, artifactNames, metadata)).isFalse()
+    }
+}

--- a/self-update-plugin/gradle-plugin/src/main/kotlin/me/tatarka/android/selfupdate/gradle/ArtifactMetadataParser.kt
+++ b/self-update-plugin/gradle-plugin/src/main/kotlin/me/tatarka/android/selfupdate/gradle/ArtifactMetadataParser.kt
@@ -55,7 +55,7 @@ internal fun parseArtifactMetadata(
 private fun checksums(path: File): List<String> {
     val result = ApkVerifier.Builder(path).build().verify()
     val digests = ApkVerifier.getContentDigestsFromResult(result, ApkSigningBlockUtils.VERSION_APK_SIGNATURE_SCHEME_V2)
-    val base64 = Base64.getEncoder().withoutPadding()
+    val base64 = Base64.getUrlEncoder().withoutPadding()
     return digests.mapNotNull { (algorithm, data) ->
         val prefix = when (algorithm) {
             ContentDigestAlgorithm.CHUNKED_SHA256 -> "v2:sha256:"


### PR DESCRIPTION
Checks for artifact changes are removals and recreates the session if needed.