### PR TITLE
When requesting the current version only download additional splits.

### DIFF
--- a/sample/src/main/java/me/tatarka/android/sample/MainActivity.kt
+++ b/sample/src/main/java/me/tatarka/android/sample/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
@@ -62,7 +63,8 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val version = packageManager.getPackageInfo(packageName, 0).versionName
+        val packageInfo = packageManager.getPackageInfo(packageName, 0)
+        val version = packageInfo.versionName
 
         setContent {
             val vm = viewModel<MainViewModel>()
@@ -77,7 +79,7 @@ class MainActivity : ComponentActivity() {
                     },
                     floatingActionButton = {
                         ExtendedFloatingActionButton(onClick = { vm.refresh() }) {
-                            Text("Refresh")
+                            Text(stringResource(R.string.refresh))
                         }
                     }
                 ) { padding ->
@@ -98,7 +100,7 @@ class MainActivity : ComponentActivity() {
                                                 vm.download(index)
                                             }
                                         }) {
-                                            Text(if (downloaded) "Install" else "Download")
+                                            Text(stringResource(if (downloaded) R.string.install else R.string.download))
                                         }
                                     }
                                 )
@@ -113,7 +115,7 @@ class MainActivity : ComponentActivity() {
                 if (updateFailed != null) {
                     AlertDialog(
                         title = {
-                            Text("Update Failed")
+                            Text(stringResource(R.string.update_failed))
                         },
                         text = {
                             Text(updateFailed ?: "")
@@ -121,7 +123,7 @@ class MainActivity : ComponentActivity() {
                         onDismissRequest = { vm.acceptFailure() },
                         confirmButton = {
                             TextButton(onClick = { vm.acceptFailure() }) {
-                                Text("Ok")
+                                Text(stringResource(R.string.ok))
                             }
                         },
                     )
@@ -139,8 +141,8 @@ class MainActivity : ComponentActivity() {
             flow {
                 emit(
                     selfUpdate.check(
-//            manifestUrl = "http://10.0.2.2:8000/manifest.json",
-                        manifestUrl = "http://10.0.0.18:8000/manifest.json",
+            manifestUrl = "http://10.0.2.2:8000/manifest.json",
+//                        manifestUrl = "http://10.0.0.18:8000/manifest.json",
                         onlyUpgrades = false
                     )
                 )

--- a/sample/src/main/res/values-es/strings.xml
+++ b/sample/src/main/res/values-es/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="refresh">Actualizar</string>
+    <string name="install">Instalar</string>
+    <string name="download">Descargar</string>
+    <string name="update_failed">Actualización fallida</string>
+    <string name="ok">Aceptar</string>
+</resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,3 +1,8 @@
 <resources>
-    <string name="app_name">Self Update Sample</string>
+    <string name="app_name" translatable="false">Self Update Sample</string>
+    <string name="refresh">Refresh</string>
+    <string name="install">Install</string>
+    <string name="download">Download</string>
+    <string name="update_failed">Update Failed</string>
+    <string name="ok">OK</string>
 </resources>

--- a/self-update-core/src/androidTest/java/me/tatarka/android/selfupdate/SelfUpdateTest.kt
+++ b/self-update-core/src/androidTest/java/me/tatarka/android/selfupdate/SelfUpdateTest.kt
@@ -57,6 +57,7 @@ class SelfUpdateTest {
             notes = null,
             tags = emptySet(),
             manifestUrl = webServer.url("/"),
+            currentRelease = false,
             artifacts = listOf(Manifest.Artifact("base.apk"))
         )
         webServer.enqueue(
@@ -101,6 +102,7 @@ class SelfUpdateTest {
                 notes = null,
                 tags = emptySet(),
                 manifestUrl = webServer.url("/"),
+                currentRelease = false,
                 artifacts = listOf(Manifest.Artifact("base.apk"))
             )
         )
@@ -113,6 +115,7 @@ class SelfUpdateTest {
                 notes = null,
                 tags = emptySet(),
                 manifestUrl = webServer.url("/"),
+                currentRelease = false,
                 artifacts = listOf(Manifest.Artifact("base.apk"))
             )
         )
@@ -130,6 +133,7 @@ class SelfUpdateTest {
             notes = null,
             tags = emptySet(),
             manifestUrl = webServer.url("/"),
+            currentRelease = false,
             artifacts = listOf(Manifest.Artifact("base.apk"))
         )
         webServer.enqueue(
@@ -155,6 +159,7 @@ class SelfUpdateTest {
             notes = null,
             tags = emptySet(),
             manifestUrl = webServer.url("/"),
+            currentRelease = false,
             artifacts = listOf(
                 Manifest.Artifact("base.apk"),
                 Manifest.Artifact("base-x86_64.apk")
@@ -213,6 +218,7 @@ class SelfUpdateTest {
             notes = null,
             tags = emptySet(),
             manifestUrl = webServer.url("/"),
+            currentRelease = false,
             artifacts = listOf(Manifest.Artifact("base.apk"))
         )
         webServer.enqueue(
@@ -264,6 +270,7 @@ class SelfUpdateTest {
             notes = null,
             tags = emptySet(),
             manifestUrl = webServer.url("/"),
+            currentRelease = false,
             artifacts = listOf(Manifest.Artifact("base.apk"))
         )
         webServer.enqueue(
@@ -315,6 +322,7 @@ class SelfUpdateTest {
             notes = null,
             tags = emptySet(),
             manifestUrl = webServer.url("/"),
+            currentRelease = false,
             artifacts = listOf(Manifest.Artifact("base.apk"))
         )
         webServer.enqueue(
@@ -331,6 +339,7 @@ class SelfUpdateTest {
             notes = null,
             tags = emptySet(),
             manifestUrl = webServer.url("/"),
+            currentRelease = false,
             artifacts = listOf(
                 Manifest.Artifact("base.apk"),
                 Manifest.Artifact("base-x86_64.apk")
@@ -362,6 +371,7 @@ class SelfUpdateTest {
             notes = null,
             tags = emptySet(),
             manifestUrl = webServer.url("/"),
+            currentRelease = false,
             artifacts = listOf(
                 Manifest.Artifact("base.apk"),
                 Manifest.Artifact("base-x86_64.apk")
@@ -387,6 +397,7 @@ class SelfUpdateTest {
             notes = null,
             tags = emptySet(),
             manifestUrl = webServer.url("/"),
+            currentRelease = false,
             artifacts = listOf(Manifest.Artifact("base.apk"))
         )
         webServer.enqueue(
@@ -404,6 +415,38 @@ class SelfUpdateTest {
         val sessionInfo = installer.mySessions.first()
         installer.openSession(sessionInfo.sessionId).use { session ->
             assertThat(session).hasArtifactContents("base.apk")
+        }
+    }
+
+    @Test
+    fun on_same_version_only_downloads_new_language_splits() = runTest {
+        val release = SelfUpdate.Release(
+            versionName = "1.0",
+            versionCode = 1L,
+            notes = null,
+            tags = emptySet(),
+            manifestUrl = webServer.url("/"),
+            currentRelease = true,
+            artifacts = listOf(
+                Manifest.Artifact("base.apk"),
+                Manifest.Artifact("base-es.apk", language = "es"),
+            )
+        )
+        webServer.enqueue(
+            MockResponse()
+                .addHeader("Content-Length", "11")
+                .setBody("base-es.apk")
+        )
+        selfUpdate.download(release)
+        
+        assertThat(webServer.takeRequest()).prop(RecordedRequest::path)
+            .isEqualTo("/base-es.apk")
+
+        // has downloaded artifacts fully
+        val sessionInfo = installer.mySessions.first()
+        assertThat(sessionInfo.mode).isEqualTo(PackageInstallerCompat.SessionParams.MODE_INHERIT_EXISTING)
+        installer.openSession(sessionInfo.sessionId).use { session ->
+            assertThat(session).hasArtifactContents("base-es.apk")
         }
     }
 }

--- a/self-update-core/src/test/java/me/tatarka/android/selfupdate/FilterReleasesTest.kt
+++ b/self-update-core/src/test/java/me/tatarka/android/selfupdate/FilterReleasesTest.kt
@@ -34,7 +34,13 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
+            deviceInfo = DeviceInfo(
+                versionCode = 1,
+                sdk = 21,
+                abis = arrayOf("armeabi-v7a"),
+                densityDpi = 0,
+                languages = listOf("en_US")
+            ),
             onlyUpgrades = false,
         )
 
@@ -45,6 +51,7 @@ class FilterReleasesTest {
                 notes = null,
                 tags = emptySet(),
                 manifestUrl = manifestUrl,
+                currentRelease = true,
                 artifacts = emptyList(),
             ),
             SelfUpdate.Release(
@@ -53,6 +60,7 @@ class FilterReleasesTest {
                 notes = null,
                 tags = emptySet(),
                 manifestUrl = manifestUrl,
+                currentRelease = false,
                 artifacts = emptyList(),
             )
         )
@@ -80,7 +88,13 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
+            deviceInfo = DeviceInfo(
+                versionCode = 1,
+                sdk = 21,
+                abis = arrayOf("armeabi-v7a"),
+                densityDpi = 0,
+                languages = listOf("en_US")
+            ),
             onlyUpgrades = true,
         )
 
@@ -91,6 +105,7 @@ class FilterReleasesTest {
                 notes = null,
                 tags = emptySet(),
                 manifestUrl = manifestUrl,
+                currentRelease = false,
                 artifacts = emptyList(),
             )
         )
@@ -114,8 +129,8 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
             deviceInfo = DeviceInfo(
+                versionCode = 1,
                 sdk = 21,
                 abis = arrayOf("armeabi-v7a"),
                 densityDpi = 0,
@@ -149,8 +164,8 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
             deviceInfo = DeviceInfo(
+                versionCode = 1,
                 sdk = 21,
                 abis = arrayOf("arm64-v8a", "armeabi-v7a"),
                 densityDpi = 0,
@@ -183,8 +198,8 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
             deviceInfo = DeviceInfo(
+                versionCode = 1,
                 sdk = 21,
                 abis = arrayOf("arm64-v8a", "armeabi-v7a"),
                 densityDpi = 0,
@@ -237,8 +252,8 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
             deviceInfo = DeviceInfo(
+                versionCode = 1,
                 sdk = 33,
                 abis = arrayOf("armeabi-v7a"),
                 densityDpi = 0,
@@ -276,8 +291,8 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
             deviceInfo = DeviceInfo(
+                versionCode = 1,
                 sdk = 21,
                 abis = arrayOf("armeabi-v7a"),
                 densityDpi = 240,
@@ -315,8 +330,8 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
             deviceInfo = DeviceInfo(
+                versionCode = 1,
                 sdk = 21,
                 abis = arrayOf("armeabi-v7a"),
                 densityDpi = 200,
@@ -353,8 +368,8 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
             deviceInfo = DeviceInfo(
+                versionCode = 1,
                 sdk = 21,
                 abis = arrayOf("armeabi-v7a"),
                 densityDpi = 0,
@@ -390,8 +405,8 @@ class FilterReleasesTest {
         val result = filterReleases(
             manifestUrl = manifestUrl,
             releases = releases,
-            versionCode = 1,
             deviceInfo = DeviceInfo(
+                versionCode = 1,
                 sdk = 21,
                 abis = arrayOf("armeabi-v7a"),
                 densityDpi = 0,


### PR DESCRIPTION
Currently only handles language splits as that's the only thing that can change dynamically but plan to handle optional feature modules in the future.